### PR TITLE
Update internal references from VoiceIt2 to VoiceIt3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_success:
   - sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
   - sudo apt-get update
   - sudo apt-get install dotnet-sdk-2.1.4
-  - cd /home/travis/build/voiceittech/VoiceIt2-C-Sharp/Test && ./release.sh
+  - cd /home/travis/build/voiceittech/VoiceIt3-C-Sharp/Test && ./release.sh
 notifications:
   slack:
     secure: kQzeiUsaorfb5CQH2cYKh4TDJzKxVSRW0eKlI1W66HRnFG+vm2xtAOLwvS9nh0x5Ea3NQfyltNmQPeou+B/4E2uIdhM0xSuTjOFjRzF3qZ/FpC+P5Q643/hzmS1zbM6H8LeFwHbUIy4xsTCABj1+d4RGYjA+FwEdUcW/LS1lmMmHCHEtz0j/v9Irh9VpVn4mUKcYzMTEm7te+sG2IKwK45lQ3l2B9QKx8C+juUB1AQPV4eBJDYN/HnnbJRYzlCjEyBUsqBRhS3ujbWooU6xM+mqk0ixGmQhpgweGN9odp5QczsX3GjBywAn4Dl0v7sXLC4PmhLqJGY3N8GIrIZv4gqlZj54ZLzep90rfIpyX9yluTIvnSU81teraYGdBQmnQ1icQJn7B72tPC9/dxKbURkpnW8r/Lb6XQB1xl+tJmC+/5WAf/SRSe1gc9YCdXfnIJAserEdILjHrLaOCnKTVscdTnn+d3kRSshf4jq4R3SPlAmN/X693lqoRUH9vRHuLtHkO5G7hHkNP6xsxPvFug9lH7xX1hBJLa4A2tuBkwIavnxuw8L8vBJ2S6i0ZJUCYh9zRy9unFEDKsnn226dNYgZSv2D3xBP9Gl+59lpbfDt7Y7glN6zjSXlXKU5MK9DvpZVHcgynF7SqRnxvKy6c5igOupcVsMjd1Fd+nOyE30c=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./csharp.png" width="100%" style="width:100%" />
 
-# VoiceIt2-C\# [![travis](https://app.travis-ci.com/voiceittech/VoiceIt2-C-Sharp.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt2-C-Sharp) [![version](https://img.shields.io/nuget/v/VoiceIt)](https://www.nuget.org/packages/VoiceIt/) [![downloads](https://img.shields.io/nuget/dt/VoiceIt)](https://www.nuget.org/packages/VoiceIt/) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
+# VoiceIt3-C\# [![travis](https://app.travis-ci.com/voiceittech/VoiceIt3-C-Sharp.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt3-C-Sharp) [![version](https://img.shields.io/nuget/v/VoiceIt)](https://www.nuget.org/packages/VoiceIt/) [![downloads](https://img.shields.io/nuget/dt/VoiceIt)](https://www.nuget.org/packages/VoiceIt/) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
 
 A C# wrapper for VoiceIt's API 2.0 featuring Voice + Face Verification and Identification.
 
@@ -17,4 +17,4 @@ Contact us with any questions at support@voiceit.io
 
 ## License
 
-VoiceIt2-C# is available under the MIT license. See the LICENSE file for more info.
+VoiceIt3-C# is available under the MIT license. See the LICENSE file for more info.

--- a/Test/release.sh
+++ b/Test/release.sh
@@ -83,7 +83,7 @@ then
 
     </Project>' > VoiceIt.csproj
 
-    cp /home/travis/build/voiceittech/VoiceIt2-C-Sharp/VoiceIt2.cs ./VoiceIt.cs
+    cp /home/travis/build/voiceittech/VoiceIt3-C-Sharp/VoiceIt2.cs ./VoiceIt.cs
 
     nuget restore
     msbuild
@@ -101,7 +101,7 @@ then
         <owners>Stephen Akers</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Package Description</description>
-        <iconUrl>https://raw.githubusercontent.com/voiceittech/VoiceIt2-C-Sharp/master/voiceitlogo64.png</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/voiceittech/VoiceIt3-C-Sharp/master/voiceitlogo64.png</iconUrl>
         <dependencies>
           <group targetFramework=".NETStandard2.0">
             <dependency id="RestSharp" version="106.12.0" exclude="Build,Analyzers" />


### PR DESCRIPTION
## Summary
- Repo has been renamed from VoiceIt2-* to VoiceIt3-*.
- Updated all internal references (URLs, package names, paths) to use VoiceIt3- instead of VoiceIt2-.

## Test plan
- [ ] Verify builds/tests pass with updated references
- [ ] Confirm all links point to correct VoiceIt3-* repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)