### PR TITLE
Remove SwitchSubAccountType (dead endpoint)

### DIFF
--- a/Test/testcsharp/Tests.cs
+++ b/Test/testcsharp/Tests.cs
@@ -229,11 +229,6 @@ namespace testcsharpwrapper
             AssertEqual(status, 201);
             AssertEqual(responseCode, "SUCC");
 
-            x = myVoiceIt.SwitchSubAccountType(subAccountManagedAPIKey);
-            (status, responseCode) = Deserialize(x);
-            AssertEqual(status, 200);
-            AssertEqual(responseCode, "SUCC");
-
             x = myVoiceIt.RegenerateSubAccountAPIToken(subAccountManagedAPIKey);
             (status, responseCode) = Deserialize(x);
             AssertEqual(status, 200);

--- a/VoiceIt2.cs
+++ b/VoiceIt2.cs
@@ -146,20 +146,6 @@ namespace VoiceIt2API
             return Task.FromResult(response.Content).GetAwaiter().GetResult();
         }
 
-        public string SwitchSubAccountType(string subAccountAPIKey)
-        {
-            var request = new RestRequest
-            {
-                Resource = "/subaccount/" + subAccountAPIKey + "/switchType",
-                Method = RestSharp.Method.POST
-            };
-            if (notificationUrl != "")
-            {
-              request.AddParameter("notificationURL", notificationUrl);
-            }
-            IRestResponse response = client.Execute(request);
-            return Task.FromResult(response.Content).GetAwaiter().GetResult();
-        }
 
         public string RegenerateSubAccountAPIToken(string subAccountAPIKey)
         {


### PR DESCRIPTION
## Summary
- Removes `SwitchSubAccountType()` method from `VoiceIt2.cs` — calls non-existent `/subaccount/{key}/switchType` endpoint
- Removes corresponding test assertions

## Test plan
- [ ] Verify no remaining references to `switchType` in codebase
- [ ] Run existing sub-account tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)