### PR TITLE
Rebrand VoiceIt2 to VoiceIt3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - wget -O ~/faceEnrollmentB3.mp4 https://drive.voiceit.io/files/faceEnrollmentB3.mp4
   - wget -O ~/faceVerificationB1.mp4 https://drive.voiceit.io/files/faceVerificationB1.mp4
 script:
-  - cd Test && cp ../VoiceIt2.cs testcsharp/VoiceIt2.cs && nuget restore && msbuild && cd testcsharp/bin/Debug && mono testcsharp2.exe
+  - cd Test && cp ../VoiceIt3.cs testcsharp/VoiceIt3.cs && nuget restore && msbuild && cd testcsharp/bin/Debug && mono testcsharp2.exe
 after_success:
   - curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
   - sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg

--- a/Test/release.sh
+++ b/Test/release.sh
@@ -63,8 +63,8 @@ then
   if [[ $wrapperplatformversion = $version ]];
   then
 
-    unzip VoiceIt2.zip
-    cd VoiceIt2
+    unzip VoiceIt3.zip
+    cd VoiceIt3
 
     echo '<Project Sdk="Microsoft.NET.Sdk">
 
@@ -83,7 +83,7 @@ then
 
     </Project>' > VoiceIt.csproj
 
-    cp /home/travis/build/voiceittech/VoiceIt3-C-Sharp/VoiceIt2.cs ./VoiceIt.cs
+    cp /home/travis/build/voiceittech/VoiceIt3-C-Sharp/VoiceIt3.cs ./VoiceIt.cs
 
     nuget restore
     msbuild

--- a/Test/testcsharp/Tests.cs
+++ b/Test/testcsharp/Tests.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.IO;
 using System.Web.Script.Serialization;
-using VoiceIt2API;
+using VoiceIt3API;
 
 namespace testcsharpwrapper
 {
@@ -107,7 +107,7 @@ namespace testcsharpwrapper
 
             string viapikey = Environment.GetEnvironmentVariable("VIAPIKEY");
             string viapitoken = Environment.GetEnvironmentVariable("VIAPITOKEN");
-            VoiceIt2 myVoiceIt = new VoiceIt2(viapikey, viapitoken);
+            VoiceIt3 myVoiceIt = new VoiceIt3(viapikey, viapitoken);
             System.IO.File.WriteAllText(Environment.GetEnvironmentVariable("HOME") + "/platformVersion", myVoiceIt.GetVersion());
             string x = "";
 

--- a/Test/testcsharp/testcsharp.csproj
+++ b/Test/testcsharp/testcsharp.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <Compile Include="Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="VoiceIt2.cs" />
+    <Compile Include="VoiceIt3.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/VoiceIt3.cs
+++ b/VoiceIt3.cs
@@ -5,15 +5,15 @@ using System.Threading.Tasks;
 using RestSharp;
 using RestSharp.Authenticators;
 
-namespace VoiceIt2API
+namespace VoiceIt3API
 {
-    public class VoiceIt2
+    public class VoiceIt3
     {
         const string VERSION = "2.8.0";
         string notificationUrl = "";
         RestClient client;
 
-        public VoiceIt2(string apiKey, string apiToken)
+        public VoiceIt3(string apiKey, string apiToken)
         {
             client = new RestClient();
             client.BaseUrl = new Uri("https://api.voiceit.io");
@@ -22,7 +22,7 @@ namespace VoiceIt2API
             client.AddDefaultHeader("platformVersion", VERSION);
         }
 
-        public VoiceIt2(string apiKey, string apiToken, string customUrl)
+        public VoiceIt3(string apiKey, string apiToken, string customUrl)
         {
             client = new RestClient();
             client.BaseUrl = new Uri(customUrl);
@@ -32,7 +32,7 @@ namespace VoiceIt2API
         }
 
         // Overloaded constructor for proxy support
-        public VoiceIt2(string apiKey, string apiToken, string proxyUrl, int proxyPort)
+        public VoiceIt3(string apiKey, string apiToken, string proxyUrl, int proxyPort)
         {
             client = new RestClient();
             client.Proxy = new WebProxy(proxyUrl, proxyPort);


### PR DESCRIPTION
## Summary
- Rename all VoiceIt2 references to VoiceIt3 (class names, file names, namespace, README)
- Rename `VoiceIt2.cs` → `VoiceIt3.cs`
- Update namespace `VoiceIt2API` → `VoiceIt3API`
- Rename class `VoiceIt2` → `VoiceIt3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)